### PR TITLE
Design 1 detail page, Tumblr link, home content

### DIFF
--- a/src/data/architecture.ts
+++ b/src/data/architecture.ts
@@ -6,7 +6,7 @@ export const architectureGroups: ItemGroup[] = [
   {
     title: "Main Designs",
     items: [
-      { title: "Design 1", description: "Studio design project.", image: "./assets/design1.png", link: "/architecture/design-1", status: "done" },
+      { title: "Design 1 — Pages, Serenity & Cosmic Wonders", description: "A reading nook at a house courtyard.", image: "./assets/design1/hero.png", link: "/architecture/design-1", status: "done" },
       { title: "Design 2", description: "Studio design project.", image: "./assets/design2.png", link: "/architecture/design-2", status: "done" },
       { title: "Design 3", description: "Studio design project.", image: "./assets/design3.png", link: "/architecture/design-3", status: "done" },
       { title: "Design 4", description: "Coming soon.", image: "./assets/design4.png", status: "planned" },

--- a/src/data/design1.ts
+++ b/src/data/design1.ts
@@ -1,0 +1,118 @@
+// Design 1 — "Pages, Serenity & Cosmic Wonders" reading-nook board, broken
+// down into web sections. Text is transcribed from the presentation board.
+// Drop cropped board images into public/assets/design1/ using the filenames
+// referenced below (missing files fall back to a placeholder).
+
+export interface Attribute {
+  label: string;
+  value: string;
+}
+
+export interface Drawing {
+  title: string;
+  scale: string;
+  image: string;
+}
+
+export interface Detail {
+  label: string;
+  note: string;
+}
+
+export const design1 = {
+  id: "S69483 · Gaahis Yaugoob",
+  title: "Pages, Serenity & Cosmic Wonders",
+  subtitle: "A Reading Nook at a House Courtyard",
+
+  statement:
+    "Step into this enchanting reading nook, a space that invites book lovers " +
+    "to immerse themselves in a world of literary wonder. The bookshelf " +
+    "showcases your beloved books, while ambient and natural lighting bathes " +
+    "the nook in a soft glow. LED strips illuminate the spines, casting a " +
+    "spellbinding aura. Sink into the plush comfort of a bean bag, where time " +
+    "stands still as you delve into the pages of your chosen adventure. The " +
+    "mirrored flooring offers a glimpse into the boundless realms that await " +
+    "within the pages. This haven is an invitation to step inside, unplug, and " +
+    "surrender to the enchantment of literature.",
+
+  // Full board scan, shown as an overview at the top.
+  board: "./assets/design1/board.png",
+  hero: "./assets/design1/hero.png",
+
+  concept: {
+    image: "./assets/design1/bubble-diagram.png",
+    attributes: <Attribute[]> [
+      { label: "Inspiration", value: "Bedside lamp & stack of books" },
+      { label: "Materials", value: "Canvas, wood, acrylic, G.I. pipe" },
+      { label: "Lighting", value: "Diffused sunlight, LED light, ambient light" },
+      { label: "Features", value: "Bookshelves, seating, lighting" },
+      { label: "Space Size", value: "Allowed space 8ft × 8ft × 8ft" },
+      { label: "Climate Consideration", value: "Protective wall and roof, drainage" },
+      { label: "Quality Enhancement", value: "Bean bag, stool, humidifier, AC, power outlet" },
+      { label: "Feeling of Space", value: "Me, books, my fuzzy eyes against the world" },
+      { label: "Colour Palette", value: "Minimalist and natural" },
+    ],
+  },
+
+  site: {
+    image: "./assets/design1/site-analysis.png",
+    swot: {
+      Strengths: ["Natural light", "Privately owned unused land"],
+      Weaknesses: ["Limited road access", "Limited existing vegetation"],
+      Opportunities: ["Natural light for daytime lighting", "Privacy", "Less noise"],
+      Threats: ["Prone to weathering", "Harsh direct sunlight"],
+    } as Record<string, string[]>,
+  },
+
+  development: [
+    {
+      title: "Form",
+      image: "./assets/design1/form.png",
+      text:
+        "Starting from the allocated 8ft cube, a translucent volume was added " +
+        "for a dreamy glow, carried on steel supports with wooden shelving. " +
+        "Early models stacked like books but felt unnatural and left corners " +
+        "hard to reach — the final model averages the slope for a natural fit.",
+    },
+    {
+      title: "Roof Design",
+      image: "./assets/design1/roof-design.png",
+      text:
+        "A flat roof risked water pooling and a pointy top didn't fit the " +
+        "flow, so the roof was resolved into a slope that drains water to two " +
+        "points without needing a gutter.",
+    },
+  ],
+
+  drawings: <Drawing[]> [
+    { title: "Ground Floor Plan", scale: "1:20", image: "./assets/design1/ground-floor-plan.png" },
+    { title: "Roof Plan", scale: "1:20", image: "./assets/design1/roof-plan.png" },
+    { title: "Elevation E1", scale: "1:20", image: "./assets/design1/elevation-e1.png" },
+    { title: "Elevation E2", scale: "1:20", image: "./assets/design1/elevation-e2.png" },
+    { title: "Section X–X", scale: "1:20", image: "./assets/design1/section-xx.png" },
+    { title: "Section Y–Y", scale: "1:20", image: "./assets/design1/section-yy.png" },
+  ],
+
+  externalViews: [
+    { title: "Daytime", image: "./assets/design1/view-day.png" },
+    { title: "Night", image: "./assets/design1/view-night.png" },
+  ],
+
+  details: <Detail[]> [
+    { label: "Sloping Roof", note: "Matches the building form" },
+    { label: "Dual-Coloured Strands", note: "Give form to the building" },
+    { label: "Simple Door", note: "Blends in while standing out" },
+    { label: "Translucent Facade", note: "Gives the dreamy glow" },
+    { label: "LED Strips", note: "Illuminate the spines of the books" },
+    { label: "Maximum Utilisation", note: "For storage" },
+    { label: "Wooden Stool", note: "Storage, and reaching higher shelves" },
+    { label: "Bean Bag Chair", note: "For comfy reading" },
+    { label: "~1,000 Book Capacity", note: "2h of reading a day for 11 years" },
+    { label: "Acrylic Sheet", note: "Protects the mirror" },
+    { label: "Mirror Flooring", note: "Gives a spacious feeling" },
+    { label: "Leaning Concrete", note: "Provides a solid base" },
+    { label: "Keyhole Hanger", note: "Holds the building facade together" },
+    { label: "Pipe Clamp", note: "Connects plank to pipe" },
+    { label: "Rubber Ring", note: "Prevents water seepage" },
+  ],
+};

--- a/src/data/home.ts
+++ b/src/data/home.ts
@@ -1,20 +1,21 @@
-// Home / About content. TODO: replace placeholder copy with your real bio,
-// work history and education entries.
+// Home / About content.
+// NOTE: statement/work/education below are carried over from the previous
+// site, which used generic placeholder copy — replace with your real details.
 export const home = {
   name: "Your Name",
   role: "Architecture · Engineering · Code",
   statement:
-    "Architecture and engineering student who also writes code and makes art. " +
-    "This site collects design work, coding projects and drawings in one place. " +
-    "(Replace this with your real personal statement.)",
+    "I am a passionate architect and developer, blending creativity with " +
+    "technology to build impactful projects. With a focus on design and user " +
+    "experience, I aim to create functional and beautiful spaces and applications.",
 
   work: [
-    "TODO: role @ place — year–year",
-    "TODO: role @ place — year–year",
+    "Architect at XYZ Design Studio (2020 – Present)", // TODO: real role
+    "Frontend Developer at ABC Tech (2018 – 2020)", // TODO: real role
   ],
 
   education: [
-    "TODO: degree — institution — year",
-    "TODO: degree — institution — year",
+    "Master's in Architecture — University of Design (2017)", // TODO: real
+    "Bachelor's in Computer Science — Tech University (2015)", // TODO: real
   ],
 };

--- a/src/data/socials.ts
+++ b/src/data/socials.ts
@@ -5,6 +5,6 @@ export const email = "s069483@student.mnu.edu.mv";
 
 export const socials: SocialLink[] = [
   { label: "GitHub", url: "https://github.com/seven-leven" },
-  { label: "Tumblr", url: "#" }, // TODO: add Tumblr URL
+  { label: "Tumblr", url: "https://www.tumblr.com/blog/gaahis" },
   { label: "Email", url: `mailto:${email}` },
 ];

--- a/src/pages/Design1.vue
+++ b/src/pages/Design1.vue
@@ -1,0 +1,301 @@
+<script setup lang="ts">
+import { RouterLink } from "vue-router";
+import { design1 as d } from "../data/design1.ts";
+import { onImageError } from "../utils/image.ts";
+</script>
+
+<template>
+  <article class="design">
+    <RouterLink to="/architecture" class="design__back">← Architecture</RouterLink>
+
+    <!-- Title -->
+    <header class="design__header">
+      <p class="eyebrow">{{ d.id }}</p>
+      <h1 class="design__title">{{ d.title }}</h1>
+      <p class="design__subtitle">{{ d.subtitle }}</p>
+      <p class="design__statement">{{ d.statement }}</p>
+    </header>
+
+    <!-- Full board overview -->
+    <figure class="board">
+      <img :src="d.board" alt="Full presentation board" @error="onImageError" />
+      <figcaption>Full presentation board</figcaption>
+    </figure>
+
+    <!-- Concept -->
+    <section class="sec">
+      <h2 class="sec__title">Concept</h2>
+      <div class="split">
+        <figure class="media">
+          <img :src="d.concept.image" alt="Bubble diagram" @error="onImageError" />
+        </figure>
+        <dl class="attrs">
+          <div v-for="a in d.concept.attributes" :key="a.label" class="attrs__row">
+            <dt>{{ a.label }}</dt>
+            <dd>{{ a.value }}</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+
+    <!-- Site analysis -->
+    <section class="sec">
+      <h2 class="sec__title">Site Analysis</h2>
+      <div class="split">
+        <figure class="media">
+          <img :src="d.site.image" alt="Site analysis" @error="onImageError" />
+        </figure>
+        <div class="swot">
+          <div v-for="(items, key) in d.site.swot" :key="key" class="swot__cell">
+            <h3>{{ key }}</h3>
+            <ul>
+              <li v-for="it in items" :key="it">{{ it }}</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Development -->
+    <section class="sec">
+      <h2 class="sec__title">Development</h2>
+      <div
+        v-for="step in d.development"
+        :key="step.title"
+        class="split split--wide"
+      >
+        <figure class="media">
+          <img :src="step.image" :alt="step.title" @error="onImageError" />
+        </figure>
+        <div class="prose">
+          <h3>{{ step.title }}</h3>
+          <p>{{ step.text }}</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Drawings -->
+    <section class="sec">
+      <h2 class="sec__title">Plans, Elevations &amp; Sections</h2>
+      <div class="grid">
+        <figure v-for="dr in d.drawings" :key="dr.title" class="drawing">
+          <img :src="dr.image" :alt="dr.title" @error="onImageError" />
+          <figcaption>
+            <span>{{ dr.title }}</span>
+            <span class="scale">Scale {{ dr.scale }}</span>
+          </figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <!-- External views -->
+    <section class="sec">
+      <h2 class="sec__title">External Views</h2>
+      <div class="grid grid--2">
+        <figure v-for="v in d.externalViews" :key="v.title" class="drawing">
+          <img :src="v.image" :alt="v.title" @error="onImageError" />
+          <figcaption><span>{{ v.title }}</span></figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <!-- Details -->
+    <section class="sec">
+      <h2 class="sec__title">Details</h2>
+      <ul class="details">
+        <li v-for="dt in d.details" :key="dt.label">
+          <span class="details__label">{{ dt.label }}</span>
+          <span class="details__note">{{ dt.note }}</span>
+        </li>
+      </ul>
+    </section>
+  </article>
+</template>
+
+<style scoped>
+/* Design pages use their own dark "board" palette, independent of the site. */
+.design {
+  margin: -2.5rem -1.25rem 0;
+  padding: 0 1.25rem 4rem;
+  background: #101010;
+  color: #eae6df;
+  min-height: 100vh;
+}
+.design__back {
+  display: inline-block;
+  margin: 1.5rem 0;
+  font-size: 0.85rem;
+  color: #b3aea4;
+  text-decoration: none;
+}
+.design__back:hover { color: #eae6df; }
+
+.eyebrow {
+  font-family: "Space Grotesk", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  font-size: 0.72rem;
+  color: #b5563a;
+  margin: 0 0 0.75rem;
+}
+
+.design__header {
+  max-width: 48rem;
+  margin: 1rem auto 2.5rem;
+  text-align: center;
+}
+.design__title {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: clamp(2.2rem, 6vw, 4rem);
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  line-height: 1.05;
+}
+.design__subtitle {
+  color: #b3aea4;
+  font-size: 1.05rem;
+  margin: 0 0 1.5rem;
+}
+.design__statement {
+  color: #cfcabf;
+  line-height: 1.75;
+  margin: 0;
+  text-align: left;
+}
+
+.board {
+  margin: 0 auto 3.5rem;
+  max-width: 72rem;
+}
+.board img {
+  width: 100%;
+  display: block;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+  background: #0d0d0d;
+}
+.board figcaption,
+.drawing figcaption {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  color: #8f8a80;
+  margin-top: 0.5rem;
+}
+
+.sec {
+  max-width: 72rem;
+  margin: 0 auto 3.5rem;
+}
+.sec__title {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.6rem;
+  font-weight: 600;
+  margin: 0 0 1.5rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 2px solid #b5563a;
+  display: inline-block;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  align-items: start;
+  margin-bottom: 2rem;
+}
+.split--wide { grid-template-columns: 1.4fr 1fr; }
+
+.media img {
+  width: 100%;
+  display: block;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+  background: #0d0d0d;
+}
+
+.attrs { margin: 0; display: flex; flex-direction: column; gap: 0.9rem; }
+.attrs__row {
+  border-left: 2px solid #2a2a2a;
+  padding-left: 1rem;
+}
+.attrs dt {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #b5563a;
+}
+.attrs dd { margin: 0.15rem 0 0; color: #cfcabf; }
+
+.swot {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+.swot__cell {
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+  padding: 1rem;
+}
+.swot__cell h3 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 0.9rem;
+  margin: 0 0 0.5rem;
+  color: #b5563a;
+}
+.swot__cell ul { margin: 0; padding-left: 1.1rem; color: #cfcabf; }
+.swot__cell li { font-size: 0.9rem; line-height: 1.5; }
+
+.prose h3 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 1.2rem;
+  margin: 0 0 0.6rem;
+}
+.prose p { color: #cfcabf; line-height: 1.7; margin: 0; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+.grid--2 { grid-template-columns: 1fr 1fr; }
+.drawing img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  display: block;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+  background: #0d0d0d;
+}
+.drawing figcaption { display: flex; justify-content: space-between; }
+.scale { color: #6f6a61; }
+
+.details {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem 2rem;
+}
+.details li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid #222;
+  padding-bottom: 0.5rem;
+}
+.details__label { font-weight: 600; }
+.details__note { color: #8f8a80; text-align: right; }
+
+@media (max-width: 700px) {
+  .split,
+  .split--wide,
+  .swot,
+  .grid,
+  .grid--2,
+  .details { grid-template-columns: 1fr; }
+}
+</style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,6 +1,7 @@
 import type { RouteRecordRaw } from "vue-router";
 import Home from "./pages/Home.vue";
 import Architecture from "./pages/Architecture.vue";
+import Design1 from "./pages/Design1.vue";
 import Coding from "./pages/Coding.vue";
 import Misc from "./pages/Misc.vue";
 import NotFound from "./pages/NotFound.vue";
@@ -8,6 +9,7 @@ import NotFound from "./pages/NotFound.vue";
 export const routes: RouteRecordRaw[] = [
   { path: "/", name: "home", component: Home },
   { path: "/architecture", name: "architecture", component: Architecture },
+  { path: "/architecture/design-1", name: "design-1", component: Design1 },
   { path: "/coding", name: "coding", component: Coding },
   { path: "/misc", name: "misc", component: Misc },
   { path: "/:pathMatch(.*)*", name: "not-found", component: NotFound },


### PR DESCRIPTION
## What changed

Adds the first architecture detail page and wires in real content.

- **Design 1 detail page** (`/architecture/design-1`) — the *Pages, Serenity & Cosmic Wonders* reading-nook board decomposed into web sections:
  - Header with the full concept statement
  - Concept / bubble-diagram attributes (materials, lighting, 8×8×8ft space, etc.)
  - Site analysis + **SWOT** grid
  - Development (Form & Roof Design narratives)
  - Plans, Elevations & Sections (6 drawings with scale labels)
  - External Views (day / night)
  - 15 annotated **Details**
  - All copy is transcribed straight from the presentation board.
- Design pages use their own **dark "design-board" palette** via scoped styles, intentionally independent of the site's paper/ink theme (per the plan for individual pages).
- **Tumblr** social link added (`gaahis`), shows in Home contact + footer.
- Home statement/work/education ported from the previous site.

## Why

Foundation is in place; this is the first real content page and establishes the pattern (structured data in `src/data/` → a dedicated page component) for the remaining designs.

## Reviewer notes

- Production build passes (`deno task build`, 56 modules).
- **Images are still needed**: the page reads crops from `public/assets/design1/` (`board.png`, `bubble-diagram.png`, `site-analysis.png`, drawings, views…). Missing files fall back to a neutral placeholder, so the page is fully functional without them — dropping `board.png` alone gives an immediate overview.
- Home `work`/`education` are still generic placeholder copy carried from the old site, marked `// TODO` for real details.
- Merging to `main` triggers the GitHub Pages deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)